### PR TITLE
achieve non blocking views by retrying request with stale=update_after on timeout

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -86,7 +86,13 @@ Default: 5000
 
 =head2 timeout
 
-Timeout in seconds for each HTTP request. Passed onto LWP::UserAgent
+Timeout in seconds for each HTTP request. Passed onto LWP::UserAgent.
+In case of a view or list related query where the view has not been updated in
+a long time this will timeout and a new request with the C<stale> option set to
+C<update_after> will be made to avoid blocking.
+See http://docs.couchdb.org/en/latest/api/ddoc/views.html
+
+Set this very high if you don't want stale results.
 
 Default: 30
 
@@ -117,17 +123,17 @@ If all you need is the revision a HEAD call is enough.
 
 =head2 all_docs
 
-This call returns a list of document IDs and revisions by default.
+This call returns a list of document IDs with their latest revision by default.
 Use C<include_docs> to get all Documents attached as well.
 
-    my @docs = @{ $sc->all_docs({ include_docs => 'true' }) };
+    my @docs = $sc->all_docs({ include_docs => 'true' });
 
 =head2 get_design_docs
 
-The get_design_docs call returns all design document names in an array
-reference. You can add C<include_docs => 'true'> to get the whole design document.
+The get_design_docs call returns all design document names in an array.
+You can add C<include_docs => 'true'> to get whole design documents.
 
-    my @docs = @{ $sc->get_design_docs({ dbname => 'database' }) };
+    my @docs = $sc->get_design_docs({ dbname => 'database' });
 
 Again the C<dbname> key is optional.
 

--- a/lib/Store/CouchDB.pm
+++ b/lib/Store/CouchDB.pm
@@ -591,15 +591,15 @@ sub get_view {
 
     my $path = $self->_make_path($data);
     $self->method('GET');
-    my $res = $self->_call($path, 1);
+    my $res = $self->_call($path, 'accept_stale');
 
     # fallback lookup for broken data consistency due to the way earlier
     # versions of this module where handling (or not) input data that had been
     # stringified by dumpers or otherwise internally
     # e.g. numbers were stored as strings which will be used as keys eventually
     unless ($res->{rows}->[0]) {
-        $path = $self->_make_path($data, 1);
-        $res = $self->_call($path, 1);
+        $path = $self->_make_path($data, 'compat');
+        $res = $self->_call($path, 'accept_stale');
     }
 
     return unless $res->{rows}->[0];
@@ -661,7 +661,7 @@ sub get_post_view {
 
     my $path = $self->_make_path($data);
     $self->method('POST');
-    my $res = $self->_call($path, 1, $opts);
+    my $res = $self->_call($path, 'accept_stale', $opts);
 
     my $result;
     foreach my $doc (@{ $res->{rows} }) {
@@ -692,15 +692,15 @@ sub get_view_array {
 
     my $path = $self->_make_path($data);
     $self->method('GET');
-    my $res = $self->_call($path, 1);
+    my $res = $self->_call($path, 'accept_stale');
 
     # fallback lookup for broken data consistency due to the way earlier
     # versions of this module where handling (or not) input data that had been
     # stringified by dumpers or otherwise internally
     # e.g. numbers were stored as strings which will be used as keys eventually
     unless ($res->{rows}->[0]) {
-        $path = $self->_make_path($data, 1);
-        $res = $self->_call($path, 1);
+        $path = $self->_make_path($data, 'compat');
+        $res = $self->_call($path, 'accept_stale');
     }
 
     my @result;
@@ -753,15 +753,15 @@ sub get_array_view {
 
     my $path = $self->_make_path($data);
     $self->method('GET');
-    my $res = $self->_call($path, 1);
+    my $res = $self->_call($path, 'accept_stale');
 
     # fallback lookup for broken data consistency due to the way earlier
     # versions of this module where handling (or not) input data that had been
     # stringified by dumpers or otherwise internally
     # e.g. numbers were stored as strings which will be used as keys eventually
     unless ($res->{rows}->[0]) {
-        $path = $self->_make_path($data, 1);
-        $res = $self->_call($path, 1);
+        $path = $self->_make_path($data, 'compat');
+        $res = $self->_call($path, 'accept_stale');
     }
 
     my $result;
@@ -820,7 +820,7 @@ sub list_view {
 
     $self->method('GET');
 
-    return $self->_call($path, 1);
+    return $self->_call($path, 'accept_stale');
 }
 
 =head2 changes


### PR DESCRIPTION
to avoid the retry one can simply set the timeout to a very high value before
calling a method. the default timeout has not been changed.

    $sc->timeout(999999);
    my $result = $sc->get_view({...});

also have all_docs()/get_design_docs return arrays for convenience